### PR TITLE
Fixes for Delivery Note not posting

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -449,7 +449,7 @@ def get_items_to_be_repost(voucher_type=None, voucher_no=None, doc=None, reposti
 			filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
 			fields=["item_code", "warehouse", "posting_date", "posting_time", "creation"],
 			order_by="creation asc",
-			group_by="item_code, warehouse",
+			group_by="item_code, warehouse, posting_date, posting_time, creation",
 		)
 
 	return items_to_be_repost or []


### PR DESCRIPTION
We can't create Delivery Note from Daily Orders which impacts inventory and procurement report, this pull request is supposed to fix that issue.

<img width="808" height="367" alt="image" src="https://github.com/user-attachments/assets/fd1acb58-d985-44f7-b84e-aecd8c72569e" />

